### PR TITLE
Add fullscreen toggle and new font

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -26,6 +26,15 @@ const App = () => {
         case "KeyP":
           setPerformance(!performance)
           return;
+        case "KeyF":
+          if (!document.fullscreenElement) {
+            document.documentElement.requestFullscreen().catch(() => {});
+          } else {
+            if (document.exitFullscreen) {
+              document.exitFullscreen();
+            }
+          }
+          return;
         default: return;
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ const Overlay = () => {
         <div className="title">LUX ET ARS - GALLERY</div>
         <div className="controls-box">
           <p>Move: WASD &nbsp; Jump: SPACE &nbsp; Run: SHIFT</p>
-          <p>Night Mode: N &nbsp; Toggle Performance: P</p>
+          <p>Night Mode: N &nbsp; Toggle Performance: P &nbsp; Fullscreen: F</p>
         </div>
       </div>
       <div className="dot" 

--- a/src/style/css/index.css
+++ b/src/style/css/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@600&display=swap');
+
 @font-face {
   font-family: "Sacramento";
   font-weight: normal;
@@ -48,9 +50,10 @@ body {
   background: none;
 }
 
-.welcome {  
+.welcome {
   color: white;
   font-size: 5rem;
+  font-family: 'Poppins', sans-serif;
 }
 
 .start {
@@ -67,6 +70,7 @@ body {
   transform: translateX(-50%);
   font-size: 2rem;
   font-weight: bold;
+  font-family: 'Poppins', sans-serif;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- import Poppins font
- apply Poppins to welcome/title text
- show fullscreen key in control instructions
- toggle fullscreen with `F`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f6e1144c8330910c49e5d4812da1