### PR TITLE
Add minimap and second room

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -8,6 +8,7 @@ import Building from '../Building/Building';
 import Ground from '../Ground/Ground';
 import Art from '../Art/Art';
 import Furniture from '../Furniture/Furniture';
+import MiniMap from '../MiniMap/MiniMap';
 import Camera from '../Camera/Camera';
 import Player from '../Player/Player';
 import Lights from '../Lights/Lights';
@@ -79,16 +80,20 @@ const App = () => {
              
         <Physics gravity={[0, -30, 0]}>
           <Suspense fallback={null}>
-            <Ground /> 
-            <Building />            
-            <Art />  
-            <Furniture />               
-          </Suspense>      
+            <Ground />
+            <Building />
+            <Art />
+            <Furniture />
+            <Building offset={[80,0,0]} />
+            <Art offset={[80,0,0]} />
+            <Furniture offset={[80,0,0]} />
+          </Suspense>
           <Player />       
         </Physics>
-        <Stats showPanel={0} className="fps" />
-      </Canvas>
-    </>
+          <Stats showPanel={0} className="fps" />
+          <MiniMap />
+        </Canvas>
+      </>
   );
 }
 

--- a/src/components/Art/Art.js
+++ b/src/components/Art/Art.js
@@ -2,69 +2,69 @@ import React from 'react';
 import Picture from '../Picture/Picture';
 import Display from '../Display/Display';
 
-const Art = () => {
+const Art = ({ offset = [0, 0, 0] }) => {
   
     return (
         <>
         {/* liam portrait */}
-        <Picture 
+        <Picture
             url={process.env.PUBLIC_URL + "/assets/3D/Portrait/scene.gltf"}
             scale={[4, 4, 4]}
-            position={[19.3, 7, 0]}            
+            position={[19.3 + offset[0], 7 + offset[1], 0 + offset[2]]}
             rotation={[0, -Math.PI, 0]}
             metalness={0.9}
             roughness={0.9}
         />
-        <Display position={[20, 5, 0]} size={[1, 18, 11]} />
+        <Display position={[20 + offset[0], 5 + offset[1], 0 + offset[2]]} size={[1, 18, 11]} />
            
         {/* creation of adam */}
-        <Picture 
+        <Picture
             url={process.env.PUBLIC_URL + "/assets/3D/Hands/scene.gltf"}
             scale={[0.1, 0.1, 0.1]}
-            position={[34.7, 12, 12]}            
+            position={[34.7 + offset[0], 12 + offset[1], 12 + offset[2]]}
             rotation={[0, -Math.PI / 2, Math.PI]}
             metalness={0}
             roughness={0.9}
         />
 
         {/* wedding */}
-        <Picture 
+        <Picture
             url={process.env.PUBLIC_URL + "/assets/3D/Wedding/scene.gltf"}
             scale={[2.5, 2.5, 2.5]}
-            position={[19.3, 7, 25]}            
+            position={[19.3 + offset[0], 7 + offset[1], 25 + offset[2]]}
             rotation={[Math.PI / 2, Math.PI, 0]}
             metalness={0.0}
             roughness={0.3}
         />
-         <Display position={[20, 5, 25]} size={[1, 18, 11]} />
+         <Display position={[20 + offset[0], 5 + offset[1], 25 + offset[2]]} size={[1, 18, 11]} />
 
         {/* wilson portrait */}
-         <Picture 
+         <Picture
             url={process.env.PUBLIC_URL + "/assets/3D/Wilson/scene.gltf"}
             scale={[2.5, 2.5, 2.5 ]}
-            position={[-19.3, 7, 0]}            
+            position={[-19.3 + offset[0], 7 + offset[1], 0 + offset[2]]}
             rotation={[-Math.PI / 2, 0, 0]}
             metalness={0}
             roughness={0.3}
         />
-         <Display position={[-20, 5, 0]} size={[1, 18, 11]} />
+         <Display position={[-20 + offset[0], 5 + offset[1], 0 + offset[2]]} size={[1, 18, 11]} />
 
         {/* old man portrait */}
-        <Picture 
+        <Picture
             url={process.env.PUBLIC_URL + "/assets/3D/OldMan/scene.gltf"}
             scale={[4, 4, 4]}
-            position={[-19.4, 7, 25]}            
+            position={[-19.4 + offset[0], 7 + offset[1], 25 + offset[2]]}
             rotation={[0, 0, 0]}
             metalness={0.9}
             roughness={0.9}
         />
-         <Display position={[-20, 5, 25]} size={[1, 18, 11]} />
+         <Display position={[-20 + offset[0], 5 + offset[1], 25 + offset[2]]} size={[1, 18, 11]} />
 
          {/* girl portrait */}
-         <Picture 
+         <Picture
             url={process.env.PUBLIC_URL + "/assets/3D/Girl/scene.gltf"}
             scale={[6.5, 6.5, 6.5]}
-            position={[-34.6, 10, 12]}            
+            position={[-34.6 + offset[0], 10 + offset[1], 12 + offset[2]]}
             rotation={[-Math.PI / 2, 0, 0]}
             metalness={0.7}
             roughness={0.8}

--- a/src/components/Building/Building.js
+++ b/src/components/Building/Building.js
@@ -3,58 +3,59 @@ import Wall from '../Wall/Wall';
 import WindowFrame from '../WindowFrame/WindowFrame';
 import Glass from '../Glass/Glass';
 
-const Building = () => {
+const Building = ({ offset = [0, 0, 0] }) => {
   
     return (
         <>
-            <Wall 
+            <Wall
                 position={[0, 0, -13.5]}
+                offset={offset}
                 modelUrl={process.env.PUBLIC_URL + "/assets/3D/Wall/scene.gltf"}
                 mapUrl={process.env.PUBLIC_URL + "/assets/3D/Wall/Textures/White_Wall.jpg"}
                 normalMapUrl={process.env.PUBLIC_URL + "/assets/3D/Wall/Textures/White_Wall_NORMAL.jpg"}
             />
 
             {/* side windows */}
-            <WindowFrame 
+            <WindowFrame
                 scale={[0.008, 0.008, 0.008]}
-                position={[6.5, 8.5, -15]}
+                position={[6.5 + offset[0], 8.5 + offset[1], -15 + offset[2]]}
                 rotation={[0, Math.PI ,0]}
                 modelUrl={process.env.PUBLIC_URL + "/assets/3D/WindowNoGlassL/scene.gltf"}
                 mapUrl={process.env.PUBLIC_URL + "/assets/3D/WindowNoGlassL/Textures/Material_49_baseColor.png"}
             />
-            <WindowFrame 
+            <WindowFrame
                 scale={[0.008, 0.008, 0.008]}
-                position={[-6.5, 8.5, -15]}
+                position={[-6.5 + offset[0], 8.5 + offset[1], -15 + offset[2]]}
                 rotation={[0, Math.PI ,0]}
                 modelUrl={process.env.PUBLIC_URL + "/assets/3D/WindowNoGlassR/scene.gltf"}
                 mapUrl={process.env.PUBLIC_URL + "/assets/3D/WindowNoGlassR/Textures/Material_49_baseColor.png"}
             />
-            <Glass            
+            <Glass
                 scale={[0.008, 0.008, 0.008]}
-                position={[6.5, 8.5, -15]}
+                position={[6.5 + offset[0], 8.5 + offset[1], -15 + offset[2]]}
                 rotation={[0, 0, 0]}
-                url={process.env.PUBLIC_URL + "/assets/3D/WindowGlassL/scene.gltf"}                        
+                url={process.env.PUBLIC_URL + "/assets/3D/WindowGlassL/scene.gltf"}
             />
-            <Glass            
+            <Glass
                 scale={[0.008, 0.008, 0.008]}
-                position={[-6.5, 8.5, -15]}
+                position={[-6.5 + offset[0], 8.5 + offset[1], -15 + offset[2]]}
                 rotation={[0, 0, 0]}
-                url={process.env.PUBLIC_URL + "/assets/3D/WindowGlassR/scene.gltf"}                        
+                url={process.env.PUBLIC_URL + "/assets/3D/WindowGlassR/scene.gltf"}
             />
 
             {/* roof */}
-            <WindowFrame 
+            <WindowFrame
                 scale={[2.7, 2.7, 2.7]}
-                position={[0, 27, 13.2]}
+                position={[0 + offset[0], 27 + offset[1], 13.2 + offset[2]]}
                 rotation={[0, 0, 0]}
                 modelUrl={process.env.PUBLIC_URL + "/assets/3D/RoofNoGlass/scene.gltf"}
                 mapUrl={process.env.PUBLIC_URL + "/assets/3D/RoofNoGlass/Textures/Material_49_baseColor.png"}
             />
-            <Glass            
+            <Glass
                 scale={[2.7, 2.7, 2.7]}
-                position={[0, 27, 13.2]}
+                position={[0 + offset[0], 27 + offset[1], 13.2 + offset[2]]}
                 rotation={[0, 0, 0]}
-                url={process.env.PUBLIC_URL + "/assets/3D/RoofGlass/scene.gltf"}                        
+                url={process.env.PUBLIC_URL + "/assets/3D/RoofGlass/scene.gltf"}
             />
         </>
 

--- a/src/components/Furniture/Furniture.js
+++ b/src/components/Furniture/Furniture.js
@@ -1,25 +1,25 @@
 import React from 'react';
 import Bench from '../Bench/Bench';
 
-const Furniture = () => {
+const Furniture = ({ offset = [0, 0, 0] }) => {
   
     return (
         <>
-            <Bench 
+            <Bench
               url={process.env.PUBLIC_URL + "/assets/3D/Bench/scene.gltf"}
               scale={[0.11, 0.11, 0.11]}
-              position={[0, 0, 3]}
+              position={[0 + offset[0], 0 + offset[1], 3 + offset[2]]}
               rotation={[0, 0, 0]}
               physicsSize={[10, 3, 1]}
-              physicsPosition={[0, 0, 3]}
+              physicsPosition={[0 + offset[0], 0 + offset[1], 3 + offset[2]]}
             />
             <Bench
               url={process.env.PUBLIC_URL + "/assets/3D/SmallBench/scene.gltf"}
               scale={[0.09, 0.09, 0.09]}
-              position={[0, 1.5, 21.5]}
+              position={[0 + offset[0], 1.5 + offset[1], 21.5 + offset[2]]}
               rotation={[0, 0, 0]}
               physicsSize={[8, 3, 1]}
-              physicsPosition={[0, 0, 21.5]}             
+              physicsPosition={[0 + offset[0], 0 + offset[1], 21.5 + offset[2]]}
             />
         </>
     );

--- a/src/components/Ground/Ground.js
+++ b/src/components/Ground/Ground.js
@@ -43,12 +43,12 @@ const Ground = () => {
             
             <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.1, 22]} >
                 <Reflector>
-                    <planeBufferGeometry attach="geometry" args={[70, 75]}  />
+                    <planeBufferGeometry attach="geometry" args={[240, 75]}  />
                 </Reflector>
             </mesh>
 
             <mesh ref={ref} receiveShadow>
-                <planeBufferGeometry attach="geometry" args={[70, 75]} />
+                <planeBufferGeometry attach="geometry" args={[240, 75]} />
                 <meshPhysicalMaterial 
                     attach="material"
                     reflectivity={0}

--- a/src/components/MiniMap/MiniMap.js
+++ b/src/components/MiniMap/MiniMap.js
@@ -1,0 +1,28 @@
+import React, { useRef } from 'react';
+import { Html, useThree, useFrame } from '@react-three/drei';
+import * as THREE from 'three';
+
+const MiniMap = ({ size = 150 }) => {
+  const dotRef = useRef();
+  const { camera } = useThree();
+
+  useFrame(() => {
+    const x = camera.position.x;
+    const z = camera.position.z;
+    const px = THREE.MathUtils.mapLinear(x, -120, 120, 0, size);
+    const pz = THREE.MathUtils.mapLinear(z, 55, -20, 0, size);
+    if (dotRef.current) {
+      dotRef.current.style.transform = `translate(${px}px, ${pz}px)`;
+    }
+  });
+
+  return (
+    <Html fullscreen>
+      <div className="minimap" style={{ width: size, height: size }}>
+        <div ref={dotRef} className="minimap-dot" />
+      </div>
+    </Html>
+  );
+};
+
+export default MiniMap;

--- a/src/components/Wall/Wall.js
+++ b/src/components/Wall/Wall.js
@@ -5,43 +5,44 @@ import * as THREE from 'three';
 import { useBox } from "use-cannon";
 import { draco } from 'drei';
 
-const Wall = ({ 
+const Wall = ({
     scale,
     position,
     rotation,
     modelUrl,
     mapUrl,
-    normalMapUrl 
+    normalMapUrl,
+    offset = [0, 0, 0]
 }) => {
     let texture, normal;
     const size = 20;
 
     const { scene } = useLoader(GLTFLoader, modelUrl, draco("https://www.gstatic.com/draco/versioned/decoders/1.4.0/"));
 
-    const [refFront] = useBox(() => ({ 
-        type: "static", 
+    const [refFront] = useBox(() => ({
+        type: "static",
         args: [70, 50, 1],
-        position: [0, 0, -17],
+        position: [offset[0] + 0, offset[1] + 0, offset[2] - 17],
     }));
-    const [refBack] = useBox(() => ({ 
-        type: "static", 
+    const [refBack] = useBox(() => ({
+        type: "static",
         args: [70, 50, 1],
-        position: [0, 0, 44],
+        position: [offset[0] + 0, offset[1] + 0, offset[2] + 44],
     }));
-    const [refL] = useBox(() => ({ 
-        type: "static", 
+    const [refL] = useBox(() => ({
+        type: "static",
         args: [1, 50, 80],
-        position: [-39.5, 0, 0],
+        position: [offset[0] - 39.5, offset[1] + 0, offset[2] + 0],
     }));
-    const [refR] = useBox(() => ({ 
-        type: "static", 
+    const [refR] = useBox(() => ({
+        type: "static",
         args: [1, 50, 80],
-        position: [39.5, 0, 0],
+        position: [offset[0] + 39.5, offset[1] + 0, offset[2] + 0],
     }));
-    const [refTop] = useBox(() => ({ 
-        type: "static", 
+    const [refTop] = useBox(() => ({
+        type: "static",
         args: [150, 1, 150],
-        position: [0, 30, 0],
+        position: [offset[0] + 0, offset[1] + 30, offset[2] + 0],
     }));
 
     texture = useMemo(() => new THREE.TextureLoader().load(mapUrl), [mapUrl]);
@@ -73,11 +74,17 @@ const Wall = ({
                 <mesh ref={refR}/>
                 <mesh ref={refBack}/>
                 <mesh ref={refTop}/>
-                <primitive                   
-                    position={position}
+                <primitive
+                    position={[
+                        position ? position[0] + offset[0] : offset[0],
+                        position ? position[1] + offset[1] : offset[1],
+                        position ? position[2] + offset[2] : offset[2],
+                    ]}
+                    rotation={rotation}
+                    scale={scale}
                     object={scene}
                     dispose={null}
-                /> 
+                />
             </>
     )
   }

--- a/src/style/css/index.css
+++ b/src/style/css/index.css
@@ -129,3 +129,20 @@ body {
   z-index: 10;
 }
 
+.minimap {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.8);
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.minimap-dot {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: red;
+  transform: translate(-50%, -50%);
+}
+


### PR DESCRIPTION
## Summary
- build a minimap overlay component
- expand ground dimensions
- allow offset for wall, furniture, art and building components
- add another room with its own furniture and art
- display minimap in the main app
- style minimap UI

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f87047fc8330bd422a35b03fef25